### PR TITLE
[docker][traditional]Install python2 required for frontend

### DIFF
--- a/traditional/Dockerfile
+++ b/traditional/Dockerfile
@@ -9,7 +9,8 @@ RUN apt-get update && apt-get install -y \
     curl \
     make \
     supervisor \
-    unzip
+    unzip \
+    python2
 
 # Append NODE, NGINX and PHP repositories
 RUN add-apt-repository ppa:ondrej/php \


### PR DESCRIPTION
```bash
#8 21.95 gyp verb check python checking for Python executable "python" in the PATH
#8 21.95 gyp verb `which` failed Error: not found: python
#8 21.95 gyp verb `which` failed     at getNotFoundError (/app/node_modules/which/which.js:13:12)
#8 21.95 gyp verb `which` failed     at F (/app/node_modules/which/which.js:68:19)
#8 21.95 gyp verb `which` failed     at E (/app/node_modules/which/which.js:80:29)
#8 21.95 gyp verb `which` failed     at /app/node_modules/which/which.js:89:16
#8 21.95 gyp verb `which` failed     at /app/node_modules/isexe/index.js:42:5
#8 21.95 gyp verb `which` failed     at /app/node_modules/isexe/mode.js:8:5
#8 21.95 gyp verb `which` failed     at FSReqCallback.oncomplete (fs.js:191:21)
#8 21.95 gyp verb `which` failed  python Error: not found: python
#8 21.95 gyp verb `which` failed     at getNotFoundError (/app/node_modules/which/which.js:13:12)
#8 21.95 gyp verb `which` failed     at F (/app/node_modules/which/which.js:68:19)
#8 21.95 gyp verb `which` failed     at E (/app/node_modules/which/which.js:80:29)
#8 21.95 gyp verb `which` failed     at /app/node_modules/which/which.js:89:16
#8 21.95 gyp verb `which` failed     at /app/node_modules/isexe/index.js:42:5
#8 21.95 gyp verb `which` failed     at /app/node_modules/isexe/mode.js:8:5
#8 21.95 gyp verb `which` failed     at FSReqCallback.oncomplete (fs.js:191:21) {
#8 21.95 gyp verb `which` failed   code: 'ENOENT'
#8 21.95 gyp verb `which` failed }
#8 21.95 gyp ERR! configure error 
#8 21.95 gyp ERR! stack Error: Can't find Python executable "python", you can set the PYTHON env variable.
#8 21.95 gyp ERR! stack     at PythonFinder.failNoPython (/app/node_modules/node-gyp/lib/configure.js:484:19)
#8 21.95 gyp ERR! stack     at PythonFinder.<anonymous> (/app/node_modules/node-gyp/lib/configure.js:406:16)
#8 21.95 gyp ERR! stack     at F (/app/node_modules/which/which.js:68:16)
#8 21.95 gyp ERR! stack     at E (/app/node_modules/which/which.js:80:29)
#8 21.95 gyp ERR! stack     at /app/node_modules/which/which.js:89:16
#8 21.95 gyp ERR! stack     at /app/node_modules/isexe/index.js:42:5
#8 21.95 gyp ERR! stack     at /app/node_modules/isexe/mode.js:8:5
#8 21.95 gyp ERR! stack     at FSReqCallback.oncomplete (fs.js:191:21)
#8 21.95 gyp ERR! System Linux 5.10.104-linuxkit
#8 21.95 gyp ERR! command "/usr/bin/node" "/app/node_modules/node-gyp/bin/node-gyp.js" "rebuild" "--verbose" "--libsass_ext=" "--libsass_cflags=" "--libsass_ldflags=" "--libsass_library="
#8 21.95 gyp ERR! cwd /app/node_modules/node-sass

```