### PR TITLE
[docker][traditional]Install G++ required by frontend

### DIFF
--- a/traditional/Dockerfile
+++ b/traditional/Dockerfile
@@ -10,7 +10,8 @@ RUN apt-get update && apt-get install -y \
     make \
     supervisor \
     unzip \
-    python2
+    python2 \
+    g++
 
 # Append NODE, NGINX and PHP repositories
 RUN add-apt-repository ppa:ondrej/php \


### PR DESCRIPTION
Reason:
```
#9 31.54 make: Entering directory '/app/node_modules/node-sass/build'
#9 31.54   g++ -o Release/obj.target/libsass/src/libsass/src/ast.o ../src/libsass/src/ast.cpp '-DNODE_GYP_MODULE_NAME=libsass' '-DUSING_UV_SHARED=1' '-DUSING_V8_SHARED=1' '-DV8_DEPRECATION_WARNINGS=1' '-DV8_DEPRECATION_WARNINGS' '-DV8_IMMINENT_DEPRECATION_WARNINGS' '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64' '-D__STDC_FORMAT_MACROS' '-DOPENSSL_NO_PINSHARED' '-DOPENSSL_THREADS' '-DLIBSASS_VERSION="3.5.5"' -I/root/.cache/node-gyp/14.19.1/include/node -I/root/.cache/node-gyp/14.19.1/src -I/root/.cache/node-gyp/14.19.1/deps/openssl/config -I/root/.cache/node-gyp/14.19.1/deps/openssl/openssl/include -I/root/.cache/node-gyp/14.19.1/deps/uv/include -I/root/.cache/node-gyp/14.19.1/deps/zlib -I/root/.cache/node-gyp/14.19.1/deps/v8/include -I../src/libsass/include  -fPIC -pthread -Wall -Wextra -Wno-unused-parameter -O3 -fno-omit-frame-pointer -std=gnu++1y -std=c++0x -fexceptions -frtti -MMD -MF ./Release/.deps/Release/obj.target/libsass/src/libsass/src/ast.o.d.raw   -c
#9 31.54 make: g++: Command not found
#9 31.54 make: *** [src/libsass.target.mk:155: Release/obj.target/libsass/src/libsass/src/ast.o] Error 127
#9 31.54 make: Leaving directory '/app/node_modules/node-sass/build'
#9 31.54 gyp ERR! build error 
#9 31.54 gyp ERR! stack Error: `make` failed with exit code: 2
#9 31.54 gyp ERR! stack     at ChildProcess.onExit (/app/node_modules/node-gyp/lib/build.js:194:23)
#9 31.54 gyp ERR! stack     at ChildProcess.emit (events.js:400:28)
#9 31.54 gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:282:12)
#9 31.54 gyp ERR! System Linux 5.10.104-linuxkit

```