### PR TITLE
[maintenance]Define nginx server_name

### DIFF
--- a/headless/.docker/nginx.conf
+++ b/headless/.docker/nginx.conf
@@ -28,8 +28,10 @@ http {
     server {
         listen 80;
 
-        root    /app/public;
-        index   index.php;
+        server_name sylius_docker;
+
+        root /app/public;
+        index index.php;
 
         location / {
             try_files $uri /index.php$is_args$args;

--- a/traditional/.docker/nginx.conf
+++ b/traditional/.docker/nginx.conf
@@ -28,8 +28,10 @@ http {
     server {
         listen 80;
 
-        root    /app/public;
-        index   index.php;
+        server_name sylius_docker;
+
+        root /app/public;
+        index index.php;
 
         location / {
             try_files $uri /index.php$is_args$args;


### PR DESCRIPTION
The server_name will be used to map server phpstorm config and use xdebug